### PR TITLE
Fix homepage pomodoro card issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
           <h3>网页画板工具</h3>
           <p>功能丰富的在线画板，支持手写绘图、形状绘制、图片上传、文字添加等多种功能。</p>
         </a>
-        <a classtool-card" href="./tools/pomodoro.html">
+        <a class="tool-card" href="./tools/pomodoro.html">
           <h3>🍅 番茄钟待办事项</h3>
           <p>专注工作的番茄钟计时器，配合待办事项管理，数据自动保存到本地存储。</p>
           <span class="tool-link">打开工具 →</span>


### PR DESCRIPTION
Fix syntax error in Pomodoro card's class attribute to restore its styling.

---
<a href="https://cursor.com/background-agent?bcId=bc-bfcbccd5-6879-4347-bd6d-ec55781614b2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bfcbccd5-6879-4347-bd6d-ec55781614b2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

