### PR TITLE
Fix mouse position offset for non-text tools

### DIFF
--- a/tools/whiteboard.html
+++ b/tools/whiteboard.html
@@ -854,12 +854,11 @@
       
       getEventPos(e) {
         const rect = this.canvas.getBoundingClientRect();
-        const scaleX = this.canvas.width / rect.width;
-        const scaleY = this.canvas.height / rect.height;
+        const dpr = window.devicePixelRatio || 1;
         
         return {
-          x: (e.clientX - rect.left) * scaleX,
-          y: (e.clientY - rect.top) * scaleY
+          x: (e.clientX - rect.left) * dpr,
+          y: (e.clientY - rect.top) * dpr
         };
       }
       


### PR DESCRIPTION
Fix mouse position offset in whiteboard tools by correcting coordinate calculation for high-DPI displays.

The canvas context was scaled by `window.devicePixelRatio` for high-DPI support, but the `getEventPos` function incorrectly calculated coordinates using `canvas.width / rect.width` instead of `dpr`, leading to a significant offset between the mouse cursor and the actual drawing position.

---
<a href="https://cursor.com/background-agent?bcId=bc-ca58aeb8-0e93-46c9-98bc-075c2e2ffd7b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ca58aeb8-0e93-46c9-98bc-075c2e2ffd7b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

